### PR TITLE
Support submission with binary nonces in v2 routes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "Krist",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/blocks.js
+++ b/src/blocks.js
@@ -149,7 +149,8 @@ Blocks.submit = async function(hash, address, nonce) {
       schemas.block.create({
         hash: hash,
         address: address,
-        nonce: nonce,
+        // Convert a binary nonce to a string if necessary
+        nonce: Buffer.from(nonce, "binary").toString("hex"),
         time: time,
         difficulty: oldWork,
         value: value

--- a/src/controllers/blocks.js
+++ b/src/controllers/blocks.js
@@ -83,7 +83,7 @@ BlocksController.blockToJSON = function(block) {
   return blocks.blockToJSON(block); // i needed to move it but i didnt want to change 1000 lines of code ok
 };
 
-BlocksController.submitBlock = function(address, nonce) {
+BlocksController.submitBlock = function(address, rawNonce) {
   return new Promise(function(resolve, reject) {
     if (!address) {
       return reject(new errors.ErrorMissingParameter("address"));
@@ -93,15 +93,15 @@ BlocksController.submitBlock = function(address, nonce) {
       return reject(new errors.ErrorInvalidParameter("address"));
     }
 
-    if (!nonce) {
+    if (!rawNonce) {
       return reject(new errors.ErrorMissingParameter("nonce"));
     }
 
-    if (nonce.length < 1 || nonce.length > config.nonceMaxSize) {
+    if (rawNonce.length < 1 || rawNonce.length > config.nonceMaxSize) {
       return reject(new errors.ErrorInvalidParameter("nonce"));
     }
 
-    const nonce = Array.isArray(nonce) ? new Uint8Array(nonce) : nonce;
+    const nonce = Array.isArray(rawNonce) ? new Uint8Array(rawNonce) : rawNonce;
     blocks.getLastBlock().then(function(lastBlock) {
       const last = lastBlock.hash.substr(0, 12);
       const difficulty = krist.getWork();

--- a/src/controllers/blocks.js
+++ b/src/controllers/blocks.js
@@ -101,10 +101,11 @@ BlocksController.submitBlock = function(address, nonce) {
       return reject(new errors.ErrorInvalidParameter("nonce"));
     }
 
+    const nonce = Array.isArray(nonce) ? new Uint8Array(nonce) : nonce;
     blocks.getLastBlock().then(function(lastBlock) {
       const last = lastBlock.hash.substr(0, 12);
       const difficulty = krist.getWork();
-      const hash = utils.sha256(address + last + nonce);
+      const hash = utils.sha256(address, last, nonce);
 
       if (parseInt(hash.substr(0, 12), 16) <= difficulty || krist.freeNonceSubmission) {
         blocks.submit(hash, address, nonce).then(resolve).catch(reject);

--- a/src/routes/submission.js
+++ b/src/routes/submission.js
@@ -67,7 +67,7 @@ module.exports = function(app) {
 	 * @apiVersion 2.0.0
 	 *
 	 * @apiParam (BodyParameter) {String} address The address to send the reward to, if successful.
-	 * @apiParam (BodyParameter) {String} nonce The nonce to submit with.
+	 * @apiParam (BodyParameter) {String|Number[]} nonce The nonce to submit with.
 	 *
 	 * @apiSuccess {Boolean} success Whether the submission was successful or not.
 	 * @apiSuccess {Number} [work] The new difficulty for block submission (if the solution was successful).

--- a/src/schemas.js
+++ b/src/schemas.js
@@ -51,7 +51,7 @@ const Block = database.getSequelize().define("block", {
     unique: true
   },
   address: Sequelize.STRING(10),
-  nonce: Sequelize.STRING(config.nonceMaxSize || 24).BINARY,
+  nonce: Sequelize.STRING((config.nonceMaxSize || 24) * 2),
   time: Sequelize.DATE,
   difficulty: Sequelize.INTEGER(10).UNSIGNED,
   useragent: Sequelize.STRING(255)

--- a/src/schemas.js
+++ b/src/schemas.js
@@ -51,7 +51,7 @@ const Block = database.getSequelize().define("block", {
     unique: true
   },
   address: Sequelize.STRING(10),
-  nonce: Sequelize.STRING(config.nonceMaxSize || 24),
+  nonce: Sequelize.STRING(config.nonceMaxSize || 24).BINARY,
   time: Sequelize.DATE,
   difficulty: Sequelize.INTEGER(10).UNSIGNED,
   useragent: Sequelize.STRING(255)

--- a/src/utils.js
+++ b/src/utils.js
@@ -25,8 +25,12 @@ const chalk  = require("chalk");
 
 function Utils() {}
 
-Utils.sha256 = function(input) {
-  return crypto.createHash("sha256").update(input.toString()).digest("hex");
+Utils.sha256 = function(...inputs) {
+  let hash = crypto.createHash("sha256");
+  for (const input of inputs) {
+    hash = hash.update(input instanceof Uint8Array ? input : input.toString());
+  }
+  return hash.digest("hex");
 };
 
 Utils.hexToBase36 = function(input) {

--- a/src/websocket_routes/submission.js
+++ b/src/websocket_routes/submission.js
@@ -33,7 +33,7 @@ module.exports = function(websockets) {
 	 * @apiParam (WebsocketParameter) {Number} id
 	 * @apiParam (WebsocketParameter) {String="submit_block"} type
 	 * @apiParam (WebsocketParameter) {String} [address]
-	 * @apiParam (WebsocketParameter) {String} nonce
+	 * @apiParam (WebsocketParameter) {String|Number[]} nonce
 	 *
 	 * @apiSuccess {Boolean} success Whether the submission was successful or not.
 	 * @apiSuccess {Number} [work] The new difficulty for block submission (if the solution was successful).


### PR DESCRIPTION
Currently nonces must be represented as UTF-8, which means extra processing is necessary on the miner, reducing speeds slightly. This PR implements support for binary nonces in the v2 routes by specifying the `nonce` field as an array of numbers on the range 0-255, as an alternative to strings. The v1 API cannot be used to submit blocks with binary nonces.

This is a backwards-compatible change to the API, but a simple DB migration may be required on the backend (changing the `nonce` column type from `VARCHAR` to `VARCHAR BINARY`. Until I get a chance to test this I'm marking the PR as a draft.

Can we spin up kristtest again with a copy of the current DB? I have a modified version of kristforge that supports binary nonces that we can use to test functionality.