### PR TITLE
chore: use async/await where possible

### DIFF
--- a/src/controllers/addresses.js
+++ b/src/controllers/addresses.js
@@ -25,62 +25,45 @@ const errors    = require("./../errors/errors.js");
 
 function AddressesController() {}
 
-AddressesController.getAddresses = function(limit, offset) {
-  return new Promise(function(resolve, reject) {
-    if ((limit && isNaN(limit)) || (limit && limit <= 0)) {
-      return reject(new errors.ErrorInvalidParameter("limit"));
-    }
+AddressesController.getAddresses = async function(limit, offset) {
+  if ((limit && isNaN(limit)) || (limit && limit <= 0))
+    throw new errors.ErrorInvalidParameter("limit");
 
-    if ((offset && isNaN(offset)) || (offset && offset < 0)) {
-      return reject(new errors.ErrorInvalidParameter("offset"));
-    }
+  if ((offset && isNaN(offset)) || (offset && offset < 0))
+    throw new errors.ErrorInvalidParameter("offset");
 
-    addresses.getAddresses(limit, offset).then(resolve).catch(reject);
-  });
+  return addresses.getAddresses(limit, offset);
 };
 
-AddressesController.getRich = function(limit, offset) {
-  return new Promise(function(resolve, reject) {
-    if ((limit && isNaN(limit)) || (limit && limit <= 0)) {
-      return reject(new errors.ErrorInvalidParameter("limit"));
-    }
+AddressesController.getRich = async function(limit, offset) {
+  if ((limit && isNaN(limit)) || (limit && limit <= 0))
+    throw new errors.ErrorInvalidParameter("limit");
 
-    if ((offset && isNaN(offset)) || (offset && offset < 0)) {
-      return reject(new errors.ErrorInvalidParameter("offset"));
-    }
+  if ((offset && isNaN(offset)) || (offset && offset < 0))
+    throw new errors.ErrorInvalidParameter("offset");
 
-    addresses.getRich(limit, offset).then(resolve).catch(reject);
-  });
+  return addresses.getRich(limit, offset);
 };
 
-AddressesController.getAddress = function(address) {
-  return new Promise(function(resolve, reject) {
-    if (!krist.isValidKristAddress(address)) {
-      return reject(new errors.ErrorInvalidParameter("address"));
-    }
+AddressesController.getAddress = async function(address) {
+    if (!krist.isValidKristAddress(address))
+      throw new errors.ErrorInvalidParameter("address");
 
-    addresses.getAddress(address).then(function(result) {
-      if (!result) {
-        return reject(new errors.ErrorAddressNotFound());
-      }
+    const result = addresses.getAddress(address);
+    if (!result)
+      throw new errors.ErrorAddressNotFound();
 
-      resolve(result);
-    }).catch(reject);
-  });
+    return result;
 };
 
-AddressesController.getAlert = function(privatekey) {
-  return new Promise(function(resolve, reject) {
-    const address = krist.makeV2Address(privatekey);
+AddressesController.getAlert = async function(privatekey) {
+  const address = krist.makeV2Address(privatekey);
 
-    addresses.getAddress(address).then(function(result) {
-      if (!result) {
-        return reject(new errors.ErrorAddressNotFound());
-      }
+  const result = await addresses.getAddress(address);
+  if (!result)
+   throw new errors.ErrorAddressNotFound();
 
-      resolve(result.alert);
-    }).catch(reject);
-  });
+  return result.alert;
 };
 
 AddressesController.addressToJSON = function(address) {

--- a/src/controllers/blocks.js
+++ b/src/controllers/blocks.js
@@ -27,38 +27,28 @@ const errors    = require("./../errors/errors.js");
 
 function BlocksController() {}
 
-BlocksController.getBlocks = function(limit, offset, asc) {
-  return new Promise(function(resolve, reject) {
-    if ((limit && isNaN(limit)) || (limit && limit <= 0)) {
-      return reject(new errors.ErrorInvalidParameter("limit"));
-    }
+BlocksController.getBlocks = async function(limit, offset, asc) {
+  if ((limit && isNaN(limit)) || (limit && limit <= 0))
+    throw new errors.ErrorInvalidParameter("limit");
 
-    if ((offset && isNaN(offset)) || (offset && offset < 0)) {
-      return reject(new errors.ErrorInvalidParameter("offset"));
-    }
+  if ((offset && isNaN(offset)) || (offset && offset < 0))
+    throw new errors.ErrorInvalidParameter("offset");
 
-    blocks.getBlocks(limit, offset, asc).then(resolve).catch(reject);
-  });
+  return blocks.getBlocks(limit, offset, asc)
 };
 
-BlocksController.getLastBlock = function() {
-  return new Promise(function(resolve, reject) {
-    blocks.getLastBlock().then(resolve).catch(reject);
-  });
+BlocksController.getLastBlock = async function() {
+  return blocks.getLastBlock();
 };
 
-BlocksController.getBlocksByOrder = function(order, limit, offset) {
-  return new Promise(function(resolve, reject) {
-    if ((limit && isNaN(limit)) || (limit && limit <= 0)) {
-      return reject(new errors.ErrorInvalidParameter("limit"));
-    }
+BlocksController.getBlocksByOrder = async function(order, limit, offset) {
+  if ((limit && isNaN(limit)) || (limit && limit <= 0))
+    throw new errors.ErrorInvalidParameter("limit");
 
-    if ((offset && isNaN(offset)) || (offset && offset < 0)) {
-      return reject(new errors.ErrorInvalidParameter("offset"));
-    }
+  if ((offset && isNaN(offset)) || (offset && offset < 0))
+    throw new errors.ErrorInvalidParameter("offset");
 
-    blocks.getBlocksByOrder(order, limit, offset).then(resolve).catch(reject);
-  });
+  return blocks.getBlocksByOrder(order, limit, offset);
 };
 
 BlocksController.getLowestHashes = async function(limit, offset) {
@@ -71,22 +61,17 @@ BlocksController.getLowestHashes = async function(limit, offset) {
   return blocks.getLowestHashes(limit, offset);
 };
 
-BlocksController.getBlock = function(height) {
-  return new Promise(function(resolve, reject) {
-    if (isNaN(height)) {
-      return reject(new errors.ErrorInvalidParameter("height"));
-    }
+BlocksController.getBlock = async function(height) {
+  if (isNaN(height))
+    throw new errors.ErrorInvalidParameter("height");
 
-    height = Math.max(parseInt(height), 0);
+  height = Math.max(parseInt(height), 0);
 
-    blocks.getBlock(height).then(function(result) {
-      if (!result) {
-        return reject(new errors.ErrorBlockNotFound());
-      }
-
-      resolve(result);
-    }).catch(reject);
-  });
+  const result = await blocks.getBlock(height);
+  if (!result)
+    throw new errors.ErrorBlockNotFound();
+  
+  return result;
 };
 
 BlocksController.blockToJSON = function(block) {

--- a/src/controllers/names.js
+++ b/src/controllers/names.js
@@ -27,18 +27,14 @@ const errors    = require("./../errors/errors.js");
 
 function NamesController() {}
 
-NamesController.getNames = function(limit, offset) {
-  return new Promise(function(resolve, reject) {
-    if ((limit && isNaN(limit)) || (limit && limit <= 0)) {
-      return reject(new errors.ErrorInvalidParameter("limit"));
-    }
+NamesController.getNames = async function(limit, offset) {
+  if ((limit && isNaN(limit)) || (limit && limit <= 0))
+    throw new errors.ErrorInvalidParameter("limit");
 
-    if ((offset && isNaN(offset)) || (offset && offset < 0)) {
-      return reject(new errors.ErrorInvalidParameter("offset"));
-    }
+  if ((offset && isNaN(offset)) || (offset && offset < 0))
+    throw new errors.ErrorInvalidParameter("offset");
 
-    names.getNames(limit, offset).then(resolve).catch(reject);
-  });
+  return names.getNames(limit, offset);
 };
 
 NamesController.getName = async function(name) {
@@ -50,38 +46,28 @@ NamesController.getName = async function(name) {
   else throw new errors.ErrorNameNotFound();
 };
 
-NamesController.getUnpaidNames = function(limit, offset) {
-  return new Promise(function(resolve, reject) {
-    if ((limit && isNaN(limit)) || (limit && limit <= 0)) {
-      return reject(new errors.ErrorInvalidParameter("limit"));
-    }
+NamesController.getUnpaidNames = async function(limit, offset) {
+  if ((limit && isNaN(limit)) || (limit && limit <= 0))
+    throw new errors.ErrorInvalidParameter("limit");
 
-    if ((offset && isNaN(offset)) || (offset && offset < 0)) {
-      return reject(new errors.ErrorInvalidParameter("offset"));
-    }
+  if ((offset && isNaN(offset)) || (offset && offset < 0))
+    throw new errors.ErrorInvalidParameter("offset");
 
-    names.getUnpaidNames(limit, offset).then(resolve).catch(reject);
-  });
+  return names.getUnpaidNames(limit, offset);
 };
 
-NamesController.getNamesByAddress = function(address, limit, offset) {
-  return new Promise(function(resolve, reject) {
-    if ((limit && isNaN(limit)) || (limit && limit <= 0)) {
-      return reject(new errors.ErrorInvalidParameter("limit"));
-    }
+NamesController.getNamesByAddress = async function(address, limit, offset) {
+  if ((limit && isNaN(limit)) || (limit && limit <= 0))
+    throw new errors.ErrorInvalidParameter("limit");
 
-    if ((offset && isNaN(offset)) || (offset && offset < 0)) {
-      return reject(new errors.ErrorInvalidParameter("offset"));
-    }
+  if ((offset && isNaN(offset)) || (offset && offset < 0))
+    throw new errors.ErrorInvalidParameter("offset");
 
-    addresses.getAddress(address).then(function(addr) {
-      if (addr) {
-        names.getNamesByAddress(addr.address, limit, offset).then(resolve).catch(reject);
-      } else {
-        reject(new errors.ErrorAddressNotFound());
-      }
-    }).catch(reject);
-  });
+  const addr = await addresses.getAddress(address);
+  if (!addr)
+    throw new errors.ErrorAddressNotFound();
+  
+  return names.getNamesByAddress(addr.address, limit, offset);
 };
 
 NamesController.registerName = async function(req, desiredName, privatekey) {

--- a/src/controllers/transactions.js
+++ b/src/controllers/transactions.js
@@ -27,56 +27,41 @@ const errors       = require("./../errors/errors.js");
 
 function TransactionsController() {}
 
-TransactionsController.getTransactions = function (limit, offset, asc, includeMined) {
-  return new Promise(function(resolve, reject) {
-    if ((limit && isNaN(limit)) || (limit && limit <= 0)) {
-      return reject(new errors.ErrorInvalidParameter("limit"));
-    }
+TransactionsController.getTransactions = async function (limit, offset, asc, includeMined) {
+    if ((limit && isNaN(limit)) || (limit && limit <= 0))
+      throw new errors.ErrorInvalidParameter("limit");
 
-    if ((offset && isNaN(offset)) || (offset && offset < 0)) {
-      return reject(new errors.ErrorInvalidParameter("offset"));
-    }
+    if ((offset && isNaN(offset)) || (offset && offset < 0))
+      throw new errors.ErrorInvalidParameter("offset");
 
-    transactions.getTransactions(limit, offset, asc, includeMined).then(resolve).catch(reject);
-  });
+    return transactions.getTransactions(limit, offset, asc, includeMined);
 };
 
-TransactionsController.getTransactionsByAddress = function(address, limit, offset, includeMined) {
-  return new Promise(function(resolve, reject) {
-    if ((limit && isNaN(limit)) || (limit && limit <= 0)) {
-      return reject(new errors.ErrorInvalidParameter("limit"));
-    }
+TransactionsController.getTransactionsByAddress = async function(address, limit, offset, includeMined) {
+  if ((limit && isNaN(limit)) || (limit && limit <= 0))
+    throw new errors.ErrorInvalidParameter("limit");
 
-    if ((offset && isNaN(offset)) || (offset && offset < 0)) {
-      return reject(new errors.ErrorInvalidParameter("offset"));
-    }
+  if ((offset && isNaN(offset)) || (offset && offset < 0))
+    throw new errors.ErrorInvalidParameter("offset");
 
-    addresses.getAddress(address).then(function(addr) {
-      if (addr) {
-        transactions.getTransactionsByAddress(addr.address, limit, offset, includeMined).then(resolve).catch(reject);
-      } else {
-        reject(new errors.ErrorAddressNotFound());
-      }
-    }).catch(reject);
-  });
+  const addr = await addresses.getAddress(address)
+  if (!addr)
+    throw new errors.ErrorAddressNotFound();
+  
+  return transactions.getTransactionsByAddress(addr.address, limit, offset, includeMined)
 };
 
-TransactionsController.getTransaction = function(id) {
-  return new Promise(function(resolve, reject) {
-    if (isNaN(id)) {
-      return reject(new errors.ErrorInvalidParameter("id"));
-    }
+TransactionsController.getTransaction = async function(id) {
+  if (isNaN(id))
+    throw new errors.ErrorInvalidParameter("id");
 
-    id = Math.max(parseInt(id), 0);
+  id = Math.max(parseInt(id), 0);
 
-    transactions.getTransaction(id).then(function(result) {
-      if (!result) {
-        return reject(new errors.ErrorTransactionNotFound());
-      }
-
-      resolve(result);
-    }).catch(reject);
-  });
+  const result = await transactions.getTransaction(id)
+  if (!result)
+    throw new errors.ErrorTransactionNotFound();
+  
+  return result;
 };
 
 TransactionsController.makeTransaction = async function(req, privatekey, to, amount, metadata) {

--- a/src/routes/addresses.js
+++ b/src/routes/addresses.js
@@ -57,15 +57,14 @@ module.exports = function(app) {
 	 * @apiSuccess {Date} addresses.firstseen The date this address was first seen (when the first transaction to it was made).
 	 */
 
-  app.get("/", function(req, res, next) {
+  app.get("/", async function(req, res, next) {
     if (req.query.getbalance) {
-      addresses.getAddress(req.query.getbalance).then(function(address) {
-        if (address) {
-          res.send(address.balance.toString());
-        } else {
-          res.send("0");
-        }
-      });
+      const address = await addresses.getAddress(req.query.getbalance);
+      if (address) {
+        res.send(address.balance.toString());
+      } else {
+        res.send("0");
+      }
 
       return;
     }
@@ -73,78 +72,74 @@ module.exports = function(app) {
     if (req.query.alert) {
       const from = krist.makeV2Address(req.query.alert);
 
-      addresses.getAddress(from).then(function(address) {
-        if (address) {
-          res.send(address.alert);
-        } else {
-          res.send("");
-        }
-      });
+      const address = await addresses.getAddress(from);
+      if (address) {
+        res.send(address.alert);
+      } else {
+        res.send("");
+      }
 
       return;
     }
 
     if (typeof req.query.richapi !== "undefined") {
-      addresses.getRich().then(function(results) {
-        let out = "";
+      const results = await addresses.getRich();
+      let out = "";
 
-        results.rows.forEach(function(address) {
-          out += address.address.substr(0, 10);
-          out += utils.padDigits(address.balance, 8);
-          out += moment(address.firstseen).format("DD MMM YYYY");
-        });
-
-        res.send(out);
+      results.rows.forEach(function(address) {
+        out += address.address.substr(0, 10);
+        out += utils.padDigits(address.balance, 8);
+        out += moment(address.firstseen).format("DD MMM YYYY");
       });
+
+      res.send(out);
 
       return;
     }
 
     if (req.query.listtx) {
-      addresses.getAddress(req.query.listtx).then(function(address) {
-        if (address) {
-          tx.getTransactionsByAddress(address.address, typeof req.query.overview !== "undefined" ? 3 : 500, 0, true).then(function(results) {
-            let out = "";
+      const address = await addresses.getAddress(req.query.listtx);
+      if (address) {
+        const results = tx.getTransactionsByAddress(address.address, typeof req.query.overview !== "undefined" ? 3 : 500, 0, true);
+        let out = "";
 
-            results.rows.forEach(function (transaction) {
-              out += moment(transaction.time).format("MMM DD HH:mm");
+        results.rows.forEach(function (transaction) {
+          out += moment(transaction.time).format("MMM DD HH:mm");
 
-              let peer = "";
-              let sign = "";
+          let peer = "";
+          let sign = "";
 
-              if (transaction.to === address.address) {
-                peer = transaction.from;
-                sign = "+";
-              } else if (transaction.from === address.address) {
-                peer = transaction.to;
-                sign = "-";
-              }
+          if (transaction.to === address.address) {
+            peer = transaction.from;
+            sign = "+";
+          } else if (transaction.from === address.address) {
+            peer = transaction.to;
+            sign = "-";
+          }
 
-              if (!transaction.from || transaction.from.length < 10) {
-                peer = "N/A(Mined)";
-              }
+          if (!transaction.from || transaction.from.length < 10) {
+            peer = "N/A(Mined)";
+          }
 
-              if (!transaction.to || transaction.to.length < 10) {
-                peer = "N/A(Names)";
-              }
+          if (!transaction.to || transaction.to.length < 10) {
+            peer = "N/A(Names)";
+          }
 
-              out += peer;
-              out += sign;
-              out += utils.padDigits(transaction.value, 8);
+          out += peer;
+          out += sign;
+          out += utils.padDigits(transaction.value, 8);
 
-              if (typeof req.query.id !== "undefined") {
-                out += utils.padDigits(transaction.id, 8);
-              }
-            });
+          if (typeof req.query.id !== "undefined") {
+            out += utils.padDigits(transaction.id, 8);
+          }
+        });
 
-            out += "end";
+        out += "end";
 
-            res.send(out);
-          });
-        } else {
-          res.send("Error4");
-        }
-      });
+        res.send(out);
+      } else {
+        res.send("Error4");
+      }
 
       return;
     }
@@ -188,34 +183,34 @@ module.exports = function(app) {
 	 *  	        },
 	 *  	        ...
 	 */
-  app.get("/addresses", function(req, res) {
-    addressesController.getAddresses(req.query.limit, req.query.offset).then(function(results) {
-      const out = [];
+  app.get("/addresses", async function(req, res) {
+    try {
+      const results = await addressesController.getAddresses(req.query.limit, req.query.offset);
+      const addresses = [];
 
-      results.rows.forEach(function(address) {
-        out.push(addressesController.addressToJSON(address));
-      });
+      results.rows.forEach(address => addresses.push(addressesController.addressToJSON(address)));
 
       res.json({
         ok: true,
-        count: out.length,
+        count: addresses.length,
         total: results.count,
-        addresses: out
+        addresses
       });
-    }).catch(function(error) {
+    } catch(error) {
       utils.sendErrorToRes(req, res, error);
-    });
+    }
   });
 
-  app.post("/addresses/alert", function(req, res) {
-    addressesController.getAlert(req.body.privatekey).then(function(alert) {
+  app.post("/addresses/alert", async function(req, res) {
+    try {
+      const alert = await addressesController.getAlert(req.body.privatekey);
       res.json({
         ok: true,
-        alert: alert
+        alert
       });
-    }).catch(function(error) {
+    } catch(error) {
       utils.sendErrorToRes(req, res, error);
-    });
+    }
   });
 
   /**
@@ -253,23 +248,22 @@ module.exports = function(app) {
 	 *              },
 	 *              ...
 	 */
-  app.get("/addresses/rich", function(req, res) {
-    addressesController.getRich(req.query.limit, req.query.offset).then(function(results) {
-      const out = [];
+  app.get("/addresses/rich", async function(req, res) {
+    try {
+      const results = await addressesController.getRich(req.query.limit, req.query.offset);
+      const addresses = [];
 
-      results.rows.forEach(function(address) {
-        out.push(addressesController.addressToJSON(address));
-      });
+      results.rows.forEach(address => addresses.push(addressesController.addressToJSON(address)));
 
       res.json({
         ok: true,
-        count: out.length,
+        count: addresses.length,
         total: results.count,
-        addresses: out
+        addresses
       });
-    }).catch(function(error) {
+    } catch(error) {
       utils.sendErrorToRes(req, res, error);
-    });
+    }
   });
 
   /**
@@ -308,15 +302,16 @@ module.exports = function(app) {
 	 *     "parameter": "address"
 	 * }
 	 */
-  app.get("/addresses/:address", function(req, res) {
-    addressesController.getAddress(req.params.address).then(function(address) {
+  app.get("/addresses/:address", async function(req, res) {
+    try {
+      const address = await addressesController.getAddress(req.params.address);
       res.json({
         ok: true,
         address: addressesController.addressToJSON(address)
       });
-    }).catch(function(error) {
+    } catch(error) {
       utils.sendErrorToRes(req, res, error);
-    });
+    }
   });
 
 
@@ -362,13 +357,12 @@ module.exports = function(app) {
 	 *     "parameter": "address"
 	 * }
 	 */
-  app.get("/addresses/:address/names", function(req, res) {
-    namesController.getNamesByAddress(req.params.address, req.query.limit, req.query.offset).then(function(names) {
+  app.get("/addresses/:address/names", async function(req, res) {
+    try {
+      const names = await namesController.getNamesByAddress(req.params.address, req.query.limit, req.query.offset);
       const out = [];
 
-      names.rows.forEach(function (name) {
-        out.push(namesController.nameToJSON(name));
-      });
+      names.rows.forEach(name => out.push(namesController.nameToJSON(name)));
 
       res.json({
         ok: true,
@@ -376,9 +370,9 @@ module.exports = function(app) {
         total: names.count,
         names: out
       });
-    }).catch(function(error) {
+    } catch(error) {
       utils.sendErrorToRes(req, res, error);
-    });
+    }
   });
 
   /**
@@ -437,13 +431,12 @@ module.exports = function(app) {
 	 *     "parameter": "address"
 	 * }
 	 */
-  app.get("/addresses/:address/transactions", function(req, res) {
-    txController.getTransactionsByAddress(req.params.address, req.query.limit, req.query.offset, typeof req.query.excludeMined === "undefined").then(function(transactions) {
+  app.get("/addresses/:address/transactions", async function(req, res) {
+    try {
+      const transactions = await txController.getTransactionsByAddress(req.params.address, req.query.limit, req.query.offset, typeof req.query.excludeMined === "undefined");
       const out = [];
 
-      transactions.rows.forEach(function (transaction) {
-        out.push(txController.transactionToJSON(transaction));
-      });
+      transactions.rows.forEach(transaction => out.push(txController.transactionToJSON(transaction)));
 
       res.json({
         ok: true,
@@ -451,9 +444,9 @@ module.exports = function(app) {
         total: transactions.count,
         transactions: out
       });
-    }).catch(function(error) {
+    } catch(error) {
       utils.sendErrorToRes(req, res, error);
-    });
+    }
   });
 
 

--- a/src/routes/jokes.js
+++ b/src/routes/jokes.js
@@ -20,15 +20,15 @@
  */
 
 module.exports = function(app) {
-  app.get("/cdel", function(req, res) {
+  app.get("/cdel", async function(req, res) {
     res.send("Connor dominates and penetrates Ryan Smith.");
   });
 
-  app.get("/justyn", function(req, res) {
+  app.get("/justyn", async function(req, res) {
     res.send("is gay");
   });
 
-  app.get("/liggy", function(req, res) {
+  app.get("/liggy", async function(req, res) {
     res.header("Content-Type", "text/html");
 
     res.send("<!doctype html>" +

--- a/src/routes/login.js
+++ b/src/routes/login.js
@@ -48,10 +48,9 @@ module.exports = function(app) {
 	 *     "authed": false
      * }
 	 */
-  app.post("/login", function(req, res) {
-    if (!req.body.privatekey) {
+  app.post("/login", async function(req, res) {
+    if (!req.body.privatekey)
       return utils.sendErrorToRes(req, res, new errors.ErrorMissingParameter("privatekey"));
-    }
 
     const v = parseInt(req.query.v) || 2;
     let address;
@@ -67,20 +66,19 @@ module.exports = function(app) {
       return utils.sendErrorToRes(req, res, new errors.ErrorInvalidParameter("v"));
     }
 
-    addresses.verify(req, address, req.body.privatekey).then(function(results) {
-      if (results.authed) {
-        return res.json({
-          ok: true,
-          authed: true,
-          address: results.address.address
-        });
-      } else {
-        return res.json({
-          ok: true,
-          authed: false
-        });
-      }
-    });
+    const results = await addresses.verify(req, address, req.body.privatekey);
+    if (results.authed) {
+      return res.json({
+        ok: true,
+        authed: true,
+        address: results.address.address
+      });
+    } else {
+      return res.json({
+        ok: true,
+        authed: false
+      });
+    }
   });
 
   return app;

--- a/src/routes/lookup.js
+++ b/src/routes/lookup.js
@@ -437,9 +437,7 @@ module.exports = function(app) {
 
   // Error handler
   // eslint-disable-next-line no-unused-vars
-  api.use((err, req, res, next) => {
-    utils.sendErrorToRes(req, res, err);
-  });
+  api.use(async (err, req, res, next) => utils.sendErrorToRes(req, res, err));
 
   app.use("/lookup", api);
 };

--- a/src/routes/moneysupply.js
+++ b/src/routes/moneysupply.js
@@ -22,11 +22,9 @@
 const krist = require("./../krist.js");
 
 module.exports = function(app) {
-  app.get("/", function(req, res, next) {
+  app.get("/", async function(req, res, next) {
     if (typeof req.query.getmoneysupply !== "undefined") {
-      krist.getMoneySupply().then(function(supply) {
-        res.send(supply);
-      });
+      res.send(await krist.getMoneySupply());
 
       return;
     }

--- a/src/routes/submission.js
+++ b/src/routes/submission.js
@@ -113,8 +113,9 @@ module.exports = function(app) {
      *     "parameter": "nonce"
      * }
 	 */
-  app.post("/submit", function(req, res) {
-    blocksController.submitBlock(req, req.body.address, req.body.nonce).then(function(result) {
+  app.post("/submit", async function(req, res) {
+    try {
+      const result = await blocksController.submitBlock(req, req.body.address, req.body.nonce);
       res.json({
         ok: true,
         success: true,
@@ -122,7 +123,7 @@ module.exports = function(app) {
         address: addressesController.addressToJSON(result.address),
         block: blocksController.blockToJSON(result.block)
       });
-    }).catch(function(error) {
+    } catch(error) {
       if (error instanceof errors.ErrorSolutionIncorrect) {
         res.json({
           ok: true,
@@ -131,7 +132,7 @@ module.exports = function(app) {
       } else {
         utils.sendErrorToRes(req, res, error);
       }
-    });
+    }
   });
 
   return app;

--- a/src/routes/v2.js
+++ b/src/routes/v2.js
@@ -24,10 +24,9 @@ const utils  = require("./../utils.js");
 const errors = require("./../errors/errors.js");
 
 module.exports = function(app) {
-  app.get("/", function(req, res, next) {
-    if (req.query.v2) {
+  app.get("/", async function(req, res, next) {
+    if (req.query.v2)
       return res.send(krist.makeV2Address(req.query.v2));
-    }
 
     next();
   });
@@ -48,10 +47,9 @@ module.exports = function(app) {
 	 *     "address": "kre3w0i79j"
      * }
 	 */
-  app.post("/v2", function(req, res) {
-    if (!req.body.privatekey) {
+  app.post("/v2", async function(req, res) {
+    if (!req.body.privatekey)
       return utils.sendErrorToRes(req, res, new errors.ErrorMissingParameter("privatekey"));
-    }
 
     res.json({
       ok: true,

--- a/src/routes/walletversion.js
+++ b/src/routes/walletversion.js
@@ -22,10 +22,9 @@
 const krist = require("./../krist.js");
 
 module.exports = function(app) {
-  app.get("/", function(req, res, next) {
-    if (typeof req.query.getwalletversion !== "undefined") {
+  app.get("/", async function(req, res, next) {
+    if (typeof req.query.getwalletversion !== "undefined")
       return res.send(krist.getWalletVersion().toString());
-    }
 
     next();
   });
@@ -44,7 +43,7 @@ module.exports = function(app) {
      *     "walletVersion": 14
      * }
 	 */
-  app.get("/walletversion", function(req, res) {
+  app.get("/walletversion", async function(req, res) {
     res.header("Content-Type", "application/json");
 
     res.json({

--- a/src/routes/work.js
+++ b/src/routes/work.js
@@ -25,9 +25,8 @@ const names = require("./../names.js");
 
 module.exports = function(app) {
   app.get("/", async function(req, res, next) {
-    if (typeof req.query.getwork !== "undefined") {
+    if (typeof req.query.getwork !== "undefined")
       return res.send((await krist.getWork()).toString());
-    }
 
     next();
   });

--- a/src/websocket_routes/addresses.js
+++ b/src/websocket_routes/addresses.js
@@ -35,14 +35,11 @@ module.exports = function(websockets) {
 	 * @apiUse Address
 	 */
 
-  websockets.addMessageHandler("address", function(ws, message) {
-    return new Promise(function(resolve, reject) {
-      addr.getAddress(message.address).then(function(address) {
-        resolve({
-          ok: true,
-          address: addr.addressToJSON(address)
-        });
-      }).catch(reject);
-    });
+  websockets.addMessageHandler("address", async function(ws, message) {
+    const address = await addr.getAddress(message.address)
+    return {
+      ok: true,
+      address: addr.addressToJSON(address)
+    }
   });
 };

--- a/src/websocket_routes/logout.js
+++ b/src/websocket_routes/logout.js
@@ -34,7 +34,7 @@ module.exports = function(websockets) {
 	 *
 	 * @apiSuccess {Boolean} isGuest Whether the current user is a guest or not
 	 */
-  websockets.addMessageHandler("logout", function(ws) {
+  websockets.addMessageHandler("logout", async function(ws) {
     const { logDetails } = utils.getLogDetails(ws.req);
     console.log(chalk`{cyan [Websockets]} Session {bold ${ws.auth}} logged out ${logDetails}`);
 

--- a/src/websocket_routes/me.js
+++ b/src/websocket_routes/me.js
@@ -55,24 +55,19 @@ module.exports = function(websockets) {
 	 *     }
      * }
 	 */
-  websockets.addMessageHandler("me", function(ws) {
-    return new Promise(function(resolve, reject) {
-      if (ws.isGuest) {
-        resolve({
-          ok: true,
-          isGuest: true
-        });
-      } else {
-        addresses.getAddress(ws.auth).then(function(address) {
-          resolve({
-            ok: true,
-            isGuest: false,
-            address: addresses.addressToJSON(address)
-          });
-        }).catch(function(error) {
-          reject(error);
-        });
+  websockets.addMessageHandler("me", async function(ws) {
+    if (ws.isGuest) {
+      return {
+        ok: true,
+        isGuest: true
       }
-    });
+    } else {
+      const address = await addresses.getAddress(ws.auth)
+      return {
+        ok: true,
+        isGuest: false,
+        address: addresses.addressToJSON(address)
+      }
+    }
   });
 };

--- a/src/websocket_routes/submission.js
+++ b/src/websocket_routes/submission.js
@@ -78,21 +78,17 @@ module.exports = function(websockets) {
      * }
 	 */
 
-  websockets.addMessageHandler("submit_block", function(ws, message) {
-    return new Promise(function(resolve, reject) {
-      if (ws.isGuest && !message.address) {
-        return reject(new errors.ErrorMissingParameter("address"));
-      }
+  websockets.addMessageHandler("submit_block", async function(ws, message) {
+    if (ws.isGuest && !message.address)
+      throw new errors.ErrorMissingParameter("address");
 
-      blocksController.submitBlock(ws.req, message.address || ws.auth, message.nonce).then(function(result) {
-        resolve({
-          ok: true,
-          success: true,
-          work: result.work,
-          address: addressesController.addressToJSON(result.address),
-          block: blocksController.blockToJSON(result.block)
-        });
-      }).catch(reject);
-    });
+    const result = await blocksController.submitBlock(ws.req, message.address || ws.auth, message.nonce)
+    return {
+      ok: true,
+      success: true,
+      work: result.work,
+      address: addressesController.addressToJSON(result.address),
+      block: blocksController.blockToJSON(result.block)
+    }
   });
 };

--- a/src/websocket_routes/subscription.js
+++ b/src/websocket_routes/subscription.js
@@ -75,7 +75,7 @@ module.exports = function(websockets) {
 	 *     "subscription_level": ["ownTransactions", "blocks"]
      * }
 	 */
-  websockets.addMessageHandler("get_subscription_level", function(ws) {
+  websockets.addMessageHandler("get_subscription_level", async function(ws) {
     return {
       ok: true,
       subscription_level: ws.subs
@@ -100,7 +100,7 @@ module.exports = function(websockets) {
 	 *     "valid_subscription_levels": ["blocks", "ownBlocks", "transactions", "ownTransactions", "names", "ownNames","motd"]
      * }
 	 */
-  websockets.addMessageHandler("get_valid_subscription_levels", () => ({
+  websockets.addMessageHandler("get_valid_subscription_levels", async () => ({
     ok: true,
     valid_subscription_levels: websockets.validSubscriptions
   }));
@@ -130,9 +130,8 @@ module.exports = function(websockets) {
     if (!websockets.validSubscriptions.includes(event))
       throw new errors.ErrorInvalidParameter("event");
 
-    if (ws.subs.includes(event)) {
+    if (ws.subs.includes(event))
       ws.subs.splice(ws.subs.indexOf(event), 1);
-    }
 
     return {
       ok: true,

--- a/src/websocket_routes/transactions.js
+++ b/src/websocket_routes/transactions.js
@@ -49,18 +49,14 @@ module.exports = function(websockets) {
      *     "error": "insufficient_funds"
      * }
 	 */
-  websockets.addMessageHandler("make_transaction", function(ws, message) {
-    return new Promise(function(resolve, reject) {
-      if (ws.isGuest && !message.privatekey) {
-        return reject(new errors.ErrorMissingParameter("privatekey"));
-      }
+  websockets.addMessageHandler("make_transaction", async function(ws, message) {
+    if (ws.isGuest && !message.privatekey)
+     throw new errors.ErrorMissingParameter("privatekey");
 
-      txController.makeTransaction(ws.req, message.privatekey || ws.privatekey, message.to, message.amount, message.metadata).then(function(transaction) {
-        resolve({
-          ok: true,
-          transaction: txController.transactionToJSON(transaction)
-        });
-      }).catch(reject);
-    });
+    const transaction = await txController.makeTransaction(ws.req, message.privatekey || ws.privatekey, message.to, message.amount, message.metadata)
+    return {
+      ok: true,
+      transaction: txController.transactionToJSON(transaction)
+    }
   });
 };


### PR DESCRIPTION
This PR replaces all instances of `Promise`, `.catch`, and `.then` with their ES6 counterparts of `async`/`await`, where appropriate.